### PR TITLE
Upgrade Gradle and Kotlin plugin for Java 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,11 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'application'
 
-mainClassName = "to.joeli.jass.Application"
+application {
+    mainClass = "to.joeli.jass.Application"
+}
 
-def javaVersion = 1.8 // We have to use 1.8 because of the server
+def javaVersion = "1.8" // We have to use 1.8 because of the server
 def jerseyVersion = 2.29
 
 sourceSets {
@@ -41,49 +43,49 @@ repositories {
 
 dependencies {
     // Websocket Communication
-    compile 'org.eclipse.jetty.websocket:websocket-client:9.3.4.RC0'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
+    implementation 'org.eclipse.jetty.websocket:websocket-client:9.3.4.RC0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
 
     // Logging
-    compile 'org.slf4j:slf4j-api:1.7.12'
-    compile 'ch.qos.logback:logback-classic:1.1.3'
+    implementation 'org.slf4j:slf4j-api:1.7.12'
+    implementation 'ch.qos.logback:logback-classic:1.1.3'
 
     // Tensorflow
-    compile "org.tensorflow:tensorflow:1.13.1" // 1.14.0 does somehow not work!
+    implementation"org.tensorflow:tensorflow:1.13.1" // 1.14.0 does somehow not work!
 
     // CBOR
-    compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.10'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.10'
 
     // JSON
-    compile 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.5'
 
     // Utilities
-    compile 'com.google.guava:guava:27.1-jre'
-    compile 'org.apache.commons:commons-lang3:3.9'
-    compile 'commons-io:commons-io:2.6'
+    implementation 'com.google.guava:guava:27.1-jre'
+    implementation 'org.apache.commons:commons-lang3:3.9'
+    implementation 'commons-io:commons-io:2.6'
 
     // REST Endpoint
-    compile "org.glassfish.jersey.containers:jersey-container-servlet:$jerseyVersion"
-    compile "org.glassfish.jersey.core:jersey-client:$jerseyVersion"
-    compile "org.glassfish.jersey.media:jersey-media-json-jackson:$jerseyVersion"
-    compile "org.glassfish.jersey.containers:jersey-container-grizzly2-http:$jerseyVersion"
-    compile "org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion"
+    implementation"org.glassfish.jersey.containers:jersey-container-servlet:$jerseyVersion"
+    implementation"org.glassfish.jersey.core:jersey-client:$jerseyVersion"
+    implementation"org.glassfish.jersey.media:jersey-media-json-jackson:$jerseyVersion"
+    implementation"org.glassfish.jersey.containers:jersey-container-grizzly2-http:$jerseyVersion"
+    implementation"org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion"
 
     // Automated Benchmarks
-    testCompile 'org.seleniumhq.selenium:selenium-java:3.141.59'
+    testImplementation 'org.seleniumhq.selenium:selenium-java:3.141.59'
 
     // JSON Interpretation
-    testCompile 'com.shazam:shazamcrest:0.11'
+    testImplementation 'com.shazam:shazamcrest:0.11'
 
     // Micro Benchmarks
-    testCompile 'org.openjdk.jmh:jmh-core:1.21'
-    testCompile 'org.openjdk.jmh:jmh-generator-annprocess:1.21'
+    testImplementation 'org.openjdk.jmh:jmh-core:1.21'
+    testImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.21'
 
     // Tests
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'com.pholser:junit-quickcheck-core:0.5-alpha-3'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'com.pholser:junit-quickcheck-core:0.5-alpha-3'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
@@ -95,7 +97,7 @@ run {
 }
 
 buildscript {
-    ext.kotlin_version = '1.3.41'
+    ext.kotlin_version = '1.9.22'
     repositories {
         mavenCentral()
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip


### PR DESCRIPTION
Use Gradle 8.8 and Kotlin plugin 1.9.22 for Java 21 compatibility.